### PR TITLE
investigate prediction mis-match

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,8 @@ This repository is split into subprojects:
 
 # Legal
 
-The original author (Malcolm Greaves) retains copyright over all material contained within this repository. Use of this code is governed under the terms of the Apache 2.0 open source software license. See the [LICENSE](./LICENSE) file for more details.
+The original author (Malcolm Greaves) retains copyright over all material contained within this repository. [1] Use of this code is governed under the terms of the Apache 2.0 open source software license. See the [LICENSE](./LICENSE) file for more details.
+
+
+
+[1] Excludes content from the data/ directory as most of this was obtained from free and open sources on the internet (inclding the wonderful UCI ML Repository!). 

--- a/notes/rbf_kerneL_numerical_stability.md
+++ b/notes/rbf_kerneL_numerical_stability.md
@@ -1,0 +1,34 @@
+
+    The code of the numerically unstable version is below:
+    ```
+        @Deprecated
+        lazy val rbf_OLD_numerical_precision_problem: Gamma => Kernel =
+          gamma => {
+            assert(gamma > 0.0)
+            val precomp = -gamma
+            (v1, v2) => {
+              val diff = v1 - v2
+              math.exp(
+                precomp * math.sqrt(diff.dot(diff))
+              )
+            }
+          }
+    ```
+
+    Note that this follows the _exact_ definition of the rbf kernel ( exp {
+    -gamma * || v1 - v2 ||^2 ). A more stable, equivalent calculation is
+    what the code now uses:
+    ```
+       lazy val rbf: Gamma => Kernel =
+          gamma => {
+            assert(gamma > 0.0)
+            val negGamma = -gamma
+            (v1, v2) => {
+              val x = negGamma * (v1.dot(v1) + v2.dot(v2) - 2.0 *
+    v1.dot(v2))
+              math.expm1(x) + 1.0
+            }
+          }
+    ```
+
+    Note that || v1 ||^2 + || v1 ||^2 - 2 * (v1 . v2) === || v1 - v2 ||^2

--- a/smo-fun-cmd/src/main/scala/smofun/AppHelpers.scala
+++ b/smo-fun-cmd/src/main/scala/smofun/AppHelpers.scala
@@ -50,12 +50,27 @@ object AppHelpers {
     }
   }
 
-  case class ConfusionMatrix(tp: Int, fp: Int, tn: Int, fn: Int)
+  case class ConfusionMatrix(tp: Int, fp: Int, tn: Int, fn: Int) {
+
+    def addTruePositive(x: Int = 1): ConfusionMatrix =
+      copy(tp = tp + x)
+
+    def addFalsePositive(x: Int = 1): ConfusionMatrix =
+      copy(fp = fp + x)
+
+    def addTrueNegative(x: Int = 1): ConfusionMatrix =
+      copy(tn = tn + x)
+
+    def addFalseNegative(x: Int = 1): ConfusionMatrix =
+      copy(fn = fn + x)
+  }
+
   object ConfusionMatrix {
     val zero = ConfusionMatrix(0, 0, 0, 0)
   }
 
-  lazy val calcPerf: ConfusionMatrix => (Double, Double, Double) =
+  type PrecisionRecallF1 = (Double, Double, Double)
+  lazy val calcPerf: ConfusionMatrix => PrecisionRecallF1 =
     cm => {
       import cm._
 

--- a/smo-fun-cmd/src/main/scala/smofun/PerfEvalSmoM.scala
+++ b/smo-fun-cmd/src/main/scala/smofun/PerfEvalSmoM.scala
@@ -130,7 +130,8 @@ object PerfEvalSmoM extends App {
       metrics
     }
     println {
-      val (precision, recall, f1) = calcPerf(confMat)
+      val metrics = calcPerf(confMat)
+      import metrics._
       import confMat._
       s"""Performance:
           |        +    |   -       <- [Predicted]
@@ -145,6 +146,7 @@ object PerfEvalSmoM extends App {
           |Precision: ${precision * 100.0} %
           |Recall:    ${recall * 100.0} %
           |F1:        ${f1 * 100.0} %
+          |Accuracy:  ${accuracy * 100.0} %
           |""".stripMargin
     }
   }

--- a/smo-fun-cmd/src/main/scala/smofun/PredictSavedModelM.scala
+++ b/smo-fun-cmd/src/main/scala/smofun/PredictSavedModelM.scala
@@ -97,7 +97,8 @@ object PredictSavedModelM extends App {
     }
 
     println {
-      val (precision, recall, f1) = calcPerf(confMat)
+      val metrics = calcPerf(confMat)
+      import metrics._
       import confMat._
       s"""Performance:
           |        +    |   -       <- [Predicted]
@@ -112,6 +113,7 @@ object PredictSavedModelM extends App {
           |Precision: ${precision * 100.0} %
           |Recall:    ${recall * 100.0} %
           |F1:        ${f1 * 100.0} %
+          |Accuracy:  ${accuracy * 100.0} %
           |""".stripMargin
     }
 

--- a/smo-fun-core/src/main/scala/smofun/SmoHelpers.scala
+++ b/smo-fun-core/src/main/scala/smofun/SmoHelpers.scala
@@ -141,6 +141,33 @@ object SmoHelpers {
         (v1, v2) => {
           val diff = v1 - v2
           math.exp(
+            precomp * (sqEuclidNorm(v1) + sqEuclidNorm(v2) - 2.0 * sprod(v1, v2))
+          )
+        }
+      }
+
+    lazy val sqEuclidNorm: Vec => Double =
+      v => sprod(v, v)
+
+    lazy val sprod: (Vec, Vec) => Double =
+      (v1, v2) => {
+        assert(v1.length == v2.length)
+        val size = v1.length
+        var sum = 0.0
+        cfor(0)(_ < size, _ + 1) { i =>
+          sum += v1(i) * v2(i)
+        }
+        sum
+      }
+
+    @Deprecated
+    lazy val rbf_OLD: Gamma => Kernel =
+      gamma => {
+        assert(gamma > 0.0)
+        val precomp = -gamma
+        (v1, v2) => {
+          val diff = v1 - v2
+          math.exp(
             precomp * math.sqrt(diff.dot(diff))
           )
         }

--- a/smo-fun-core/src/main/scala/smofun/SmoHelpers.scala
+++ b/smo-fun-core/src/main/scala/smofun/SmoHelpers.scala
@@ -134,53 +134,13 @@ object SmoHelpers {
     lazy val linear: Kernel = (v1, v2) => v1.dot(v2)
 
     type Gamma = Double
-    lazy val rbf: Gamma => Kernel = rbf_NEW_IMPL
-
-    lazy val rbf_blas: Gamma => Kernel =
+    lazy val rbf: Gamma => Kernel =
       gamma => {
         assert(gamma > 0.0)
         val negGamma = -gamma
         (v1, v2) => {
           val x = negGamma * (v1.dot(v1) + v2.dot(v2) - 2.0 * v1.dot(v2))
           math.expm1(x) + 1.0
-        }
-      }
-
-    lazy val rbf_NEW_IMPL: Gamma => Kernel =
-      gamma => {
-        assert(gamma > 0.0)
-        val precomp = -gamma
-        (v1, v2) => {
-          math.exp(
-            precomp * (sqEuclidNorm(v1) + sqEuclidNorm(v2) - 2.0 * sprod(v1, v2))
-          )
-        }
-      }
-
-    lazy val sqEuclidNorm: Vec => Double =
-      v => sprod(v, v)
-
-    lazy val sprod: (Vec, Vec) => Double =
-      (v1, v2) => {
-        assert(v1.length == v2.length)
-        val size = v1.length
-        var sum = 0.0
-        cfor(0)(_ < size, _ + 1) { i =>
-          sum += v1(i) * v2(i)
-        }
-        sum
-      }
-
-    @Deprecated
-    lazy val rbf_OLD: Gamma => Kernel =
-      gamma => {
-        assert(gamma > 0.0)
-        val precomp = -gamma
-        (v1, v2) => {
-          val diff = v1 - v2
-          math.exp(
-            precomp * math.sqrt(diff.dot(diff))
-          )
         }
       }
 

--- a/smo-fun-core/src/main/scala/smofun/SmoHelpers.scala
+++ b/smo-fun-core/src/main/scala/smofun/SmoHelpers.scala
@@ -134,12 +134,23 @@ object SmoHelpers {
     lazy val linear: Kernel = (v1, v2) => v1.dot(v2)
 
     type Gamma = Double
-    lazy val rbf: Gamma => Kernel =
+    lazy val rbf: Gamma => Kernel = rbf_NEW_IMPL
+
+    lazy val rbf_blas: Gamma => Kernel =
+      gamma => {
+        assert(gamma > 0.0)
+        val negGamma = -gamma
+        (v1, v2) => {
+          val x = negGamma * (v1.dot(v1) + v2.dot(v2) - 2.0 * v1.dot(v2))
+          math.expm1(x) + 1.0
+        }
+      }
+
+    lazy val rbf_NEW_IMPL: Gamma => Kernel =
       gamma => {
         assert(gamma > 0.0)
         val precomp = -gamma
         (v1, v2) => {
-          val diff = v1 - v2
           math.exp(
             precomp * (sqEuclidNorm(v1) + sqEuclidNorm(v2) - 2.0 * sprod(v1, v2))
           )

--- a/smo-fun-core/src/main/scala/smofun/SvmLightHelpers.scala
+++ b/smo-fun-core/src/main/scala/smofun/SvmLightHelpers.scala
@@ -95,10 +95,10 @@ object SvmLightHelpers {
         "1 # kernel parameter -s",
         "1 # kernel parameter -r",
         "empty# kernel parameter -u",
-        s"${svm.supportVectors.head.data.length} # highest feature index",
+        s"${svm.supportVectors.head.data.length} # highest feature index, svm-light does 1-based indexing :*(",
         s"$nTrain # number of training documents",
         s"${svm.size + 1} # number of support vectors plus 1",
-        s"${svm.b} # threshold b, each following line is a SV (starting with alpha*y)"
+        s"${svm.b} # threshold b, each following line is a SV (starting with alpha*y then the features in the index:value space-delim. format)"
       )
 
       val modelSVs = svm.supportVectors.zip(svm.bothAlphaTargets)

--- a/smo-fun-core/src/test/scala/smofun/SanityCheckSmoTest.scala
+++ b/smo-fun-core/src/test/scala/smofun/SanityCheckSmoTest.scala
@@ -47,7 +47,7 @@ object SanityCheckSmoTest {
     SvmConfig(
       C = 1.0,
       tolerance = 0.0001,
-      K = rbf(1.0)
+      K = rbf(0.5)
     )
   ) _
 


### PR DESCRIPTION
During comparison with existing state-of-the-art reference implementations, I noticed a discrepancy in prediction using the RBF kernel. This PR fixes the bug by using a different calculation that, while mathematically equivalent, is a more numerically stable computation than the straightforward "Euclidian norm of the difference between vectors" part of the RBF kernel. 
